### PR TITLE
Prevent crash when MeterReporter is deallocated before upload

### DIFF
--- a/Sources/MeterReporter/MeterReporter.swift
+++ b/Sources/MeterReporter/MeterReporter.swift
@@ -28,7 +28,7 @@ public class MeterReporter {
         wellsReporter.locationProvider = IdentifierExtensionLocationProvider(baseURL: configuration.reportsURL,
                                                                              fileExtension: "mxdiagnostic")
 
-        wellsReporter.existingLogHandler = { [unowned self] in self.handleExistingLog(at: $0, date: $1) }
+        wellsReporter.existingLogHandler = { [weak self] in self?.handleExistingLog(at: $0, date: $1) }
     }
 
     public convenience init(endpointURL: URL) {

--- a/Sources/MeterReporter/MeterReporter.swift
+++ b/Sources/MeterReporter/MeterReporter.swift
@@ -16,19 +16,25 @@ public class MeterReporter {
     private let wellsReporter: WellsReporter
     public var configuration: Configuration
     private let subscriber: DiagnosticSubscriber
-    private let log: OSLog
+    private var log: OSLog { Self.log }
+    private static let log = OSLog(subsystem: "com.chimehq.MeterReporter", category: "MeterReporter")
 
     public init(configuration: Configuration) {
         self.configuration = configuration
         self.subscriber = DiagnosticSubscriber()
-        self.log = OSLog(subsystem: "com.chimehq.MeterReporter", category: "MeterReporter")
         self.wellsReporter = WellsReporter(baseURL: configuration.reportsURL,
                                            backgroundIdentifier: configuration.backgroundIdentifier)
 
         wellsReporter.locationProvider = IdentifierExtensionLocationProvider(baseURL: configuration.reportsURL,
                                                                              fileExtension: "mxdiagnostic")
 
-        wellsReporter.existingLogHandler = { [unowned self] in self.handleExistingLog(at: $0, date: $1) }
+        wellsReporter.existingLogHandler = { [weak self] in
+            guard let self = self else {
+                os_log("deallocated – cannot process log %{public}@", log: Self.log, type: .error, $0.path)
+                return
+            }
+            self.handleExistingLog(at: $0, date: $1)
+        }
     }
 
     public convenience init(endpointURL: URL) {

--- a/Sources/MeterReporter/MeterReporter.swift
+++ b/Sources/MeterReporter/MeterReporter.swift
@@ -16,25 +16,19 @@ public class MeterReporter {
     private let wellsReporter: WellsReporter
     public var configuration: Configuration
     private let subscriber: DiagnosticSubscriber
-    private var log: OSLog { Self.log }
-    private static let log = OSLog(subsystem: "com.chimehq.MeterReporter", category: "MeterReporter")
+    private let log: OSLog
 
     public init(configuration: Configuration) {
         self.configuration = configuration
         self.subscriber = DiagnosticSubscriber()
+        self.log = OSLog(subsystem: "com.chimehq.MeterReporter", category: "MeterReporter")
         self.wellsReporter = WellsReporter(baseURL: configuration.reportsURL,
                                            backgroundIdentifier: configuration.backgroundIdentifier)
 
         wellsReporter.locationProvider = IdentifierExtensionLocationProvider(baseURL: configuration.reportsURL,
                                                                              fileExtension: "mxdiagnostic")
 
-        wellsReporter.existingLogHandler = { [weak self] in
-            guard let self = self else {
-                os_log("deallocated – cannot process log %{public}@", log: Self.log, type: .error, $0.path)
-                return
-            }
-            self.handleExistingLog(at: $0, date: $1)
-        }
+        wellsReporter.existingLogHandler = { [unowned self] in self.handleExistingLog(at: $0, date: $1) }
     }
 
     public convenience init(endpointURL: URL) {


### PR DESCRIPTION
If the client calls start() on a MeterReporter instance but does not keep a strong reference to this instance, then it gets deallocated and if any log is available to upload a crash occurs after 10 seconds.
Not sure this is the best way to fix this -- maybe intentionally creating a retain cycle is preferable so that clients don't have to retain their MeterReporter.